### PR TITLE
:sparkles: Add a new route to the management of the number of graduates

### DIFF
--- a/app/Http/Controllers/Api/GraduateController.php
+++ b/app/Http/Controllers/Api/GraduateController.php
@@ -38,6 +38,15 @@ class GraduateController extends Controller
         :  jsonResponse('Datos obtenidos exitosamente', $numGraduatesData, 200);
     }
 
+    public function allDataGraduates(): JsonResponse
+    {
+        $numGraduates = NumGraduate::with(['campus', 'career', 'faculty'])->get();
+        $data = NumGraduateResource::collection($numGraduates);
+        return $data->isEmpty()
+            ?  jsonResponse('No hay datos', [], 200)
+            :  jsonResponse('Datos obtenidos exitosamente', $data, 200);
+    }
+
     /**
      * Store a newly created resource in storage.
      * 

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,6 +31,7 @@ Route::get('careers/{career}/faculty', [CareerController::class, 'displayFaculty
 Route::apiResource('campus', CampuController::class)->middleware('throttle:160,1');
 
 Route::apiResource('graduates', GraduateController::class)->middleware('throttle:160,1');
+Route::get('graduates-all', [GraduateController::class, 'allDataGraduates'])->middleware('throttle:10,1');
 Route::get('graduates/{graduates}/campus', [GraduateController::class, 'filterByCampus'])->middleware('throttle:160,1');
 Route::get('graduates/{graduates}/career', [GraduateController::class, 'filterByCareer'])->middleware('throttle:160,1');
 Route::get('graduates/{graduates}/faculty', [GraduateController::class, 'filterByFaculty'])->middleware('throttle:160,1');


### PR DESCRIPTION
A new endpoint has been added, this endpoint makes a request to a new function in the GraduateController controller. The controller responds with all the data from the NumGraduates entity, without performing any pagination, this with the goal of having all the data in a single request.